### PR TITLE
Add withdrawal retirement calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Helpful `FastAPI` documentation
 Helpful `pydantic` documentation
 
 - [Typing Iterables](https://pydantic-docs.helpmanual.io/usage/types/#typing-iterables)
+- [Field Types](https://pydantic-docs.helpmanual.io/usage/types/)
+- [Validators](https://pydantic-docs.helpmanual.io/usage/validators/)
 
 #### Pandas
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ All in one finance data crunching backend
 
 ## API
 
+API documentation
+
 ### Financial independence (FI)
 
 Financial Independence is based on the FIRE movement. Financial Independence, Retire Early (FIRE) is a movement dedicated to a program of extreme savings and investment that allows proponents to retire far earlier than traditional budgets and retirement plans would allow. By dedicating up to 70% of income to savings, followers of the FIRE movement may eventually be able to quit their jobs and live solely off small withdrawals from their portfolios decades before the conventional retirement age of 65. More information can be found [here](https://www.investopedia.com/terms/f/financial-independence-retire-early-fire.asp)
@@ -44,10 +46,10 @@ API endpoints available are
 
 ## How to run it
 
-In order to run the API locally, you would first need to run the `python .\setup.py develop` script, if it hasn't been setup locally before. Afterwards, start the API via `uvicorn`
+In order to run the API locally, you would first need to run the `python .\setup.py develop` script, if it hasn't been setup locally before, in additional the installing the requirements. Afterwards, start the API via `uvicorn`
 
 ```powershell
-pip install -r .\requirements.txt
+python -m pip install -r .\requirements.txt
 python .\setup.py develop
 uvicorn api.main:app
 ```

--- a/aiof/analytics/core.py
+++ b/aiof/analytics/core.py
@@ -174,6 +174,8 @@ def life_event(life_event_request: LifeEventRequest) -> LifeEventResponse:
     """
     if life_event_request.type == "buying a house":
         print("test")
+    elif life_event_request.type =="selling a car":
+        print("selling a car")
 
     data = LifeEventResponse(
         currentAssets = life_event_request.assets,

--- a/aiof/analytics/core.py
+++ b/aiof/analytics/core.py
@@ -7,7 +7,7 @@ import aiof.helpers as helpers
 from aiof.data.analytics import Analytics, AssetsLiabilities
 from aiof.data.asset import Asset, AssetFv
 from aiof.data.liability import Liability
-from aiof.fi.core import cost_of_raising_children
+from aiof.data.life_event import LifeEventRequest, LifeEventResponse
 
 from typing import List
 
@@ -158,12 +158,25 @@ def debt_to_income_ratio_basic_calc(
     `income` : float. 
         annual income\n
     `total_monthly_debt_payments` : float.
-        total monthly debt payments. usually include credit cards, personal loan, student loan, etc.\n
+        total monthly debt payments. usually include credit cards, personal loan, student loan, etc.
     """
     return round(((total_monthly_debt_payments * 12) / income) * 100, _round_dig)
 
 
-def life_event(
-    event: str):
-    if event == "raising children":
-        cost = cost_of_raising_children()
+def life_event(life_event_request: LifeEventRequest) -> LifeEventResponse:
+    """
+    See how a life event impacts you
+
+    Parameters
+    ----------
+    `life_event_request`: LifeEventRequest. 
+        the life event request
+    """
+    if life_event_request.type == "buying a house":
+        print("test")
+
+    data = LifeEventResponse(
+        currentAssets = life_event_request.assets,
+        currentLiabilities = life_event_request.liabilities)
+
+    return data

--- a/aiof/data/life_event.py
+++ b/aiof/data/life_event.py
@@ -1,0 +1,27 @@
+import datetime
+
+from pydantic import BaseModel, validator
+from typing import Optional
+
+
+_event_types = [
+    "having a child",
+    "buying a car",
+    "selling a car",
+    "buying a house",
+    "buying a condo",
+]
+
+class LifeEvent(BaseModel):
+    """
+    Life event class. This is used to generate a life event
+    """
+    type: str
+    amount: float
+    plannedDate: Optional[datetime.datetime]
+
+    @validator("type")
+    def type_must_be_valid(cls, t):
+        if t not in _event_types:
+            raise ValueError("Invalid type. Please use one of the following {0}".format(", ".join(str(x) for x in _event_types)))
+        return t.title()

--- a/aiof/data/life_event.py
+++ b/aiof/data/life_event.py
@@ -1,7 +1,10 @@
 import datetime
 
+from aiof.data.asset import Asset
+from aiof.data.liability import Liability
+
 from pydantic import BaseModel, validator
-from typing import Optional
+from typing import List, Optional
 
 
 _event_types = [
@@ -12,10 +15,12 @@ _event_types = [
     "buying a condo",
 ]
 
-class LifeEvent(BaseModel):
+class LifeEventRequest(BaseModel):
     """
-    Life event class. This is used to generate a life event
+    Life event request class. This is used to request specific event
     """
+    assets: List[Asset]
+    liabilities: List[Liability]
     type: str
     amount: float
     plannedDate: Optional[datetime.datetime]
@@ -25,3 +30,11 @@ class LifeEvent(BaseModel):
         if t not in _event_types:
             raise ValueError("Invalid type. Please use one of the following {0}".format(", ".join(str(x) for x in _event_types)))
         return t.title()
+
+
+class LifeEventResponse(BaseModel):
+    """
+    Life event response class. This is used to return specific response
+    """
+    currentAssets: List[Asset]
+    currentLiabilities: List[Liability] 

--- a/aiof/data/retirement.py
+++ b/aiof/data/retirement.py
@@ -1,0 +1,10 @@
+import datetime
+
+from pydantic import BaseModel
+from typing import Optional
+
+
+class WithdrawalRequest(BaseModel):
+    retirementNumber: float
+    takeOutPercentage: float
+    numberOfYears: float

--- a/aiof/property/core.py
+++ b/aiof/property/core.py
@@ -1,7 +1,6 @@
 import datetime
 import pandas as pd
 import numpy_financial as npf
-from pandas.core.frame import DataFrame
 
 import aiof.config as config
 

--- a/aiof/retirement/core.py
+++ b/aiof/retirement/core.py
@@ -1,0 +1,51 @@
+import datetime
+import pandas as pd
+import numpy_financial as npf
+
+import aiof.config as config
+
+
+# Configs
+_settings = config.get_settings()
+_round_dig = _settings.DefaultRoundingDigit
+
+
+def withdrawal_calc(
+    retirement_number: float = None,
+    take_out_percentage: float = None,
+    number_of_years: float = None,
+    as_json: bool = False) -> pd.DataFrame:
+    """
+    Calculate retirement
+
+    Parameters
+    ----------
+    `retirement_number` : float.
+        retirement number. defaults to `1,000,000`\n
+    `take_out_percentage` : float.
+        take out percentage of total retirement number. defaults to `3%`\n
+    `number_of_years` : float.
+        number of years to take money out. defaults to `35`
+    """
+    # Check for None
+    retirement_number   = retirement_number if retirement_number is not None else 1000000
+    take_out_percentage = take_out_percentage if take_out_percentage is not None else 3
+    number_of_years     = number_of_years if number_of_years is not None else 35
+
+    # Check and fix parameters
+    take_out_percentage = take_out_percentage / 100
+
+    if retirement_number < 0:
+        raise ValueError("Retirement number cannot be negative")
+    elif take_out_percentage < 0 or take_out_percentage > 100:
+        raise ValueError("Take out percentage must be between 0 and 100")
+    elif number_of_years < 0 or number_of_years > 100:
+        raise ValueError("Number of years must be between 0 and 100")
+
+    # Initial data frame
+    df = pd.DataFrame(columns=["year", "principalPaid", "interestPaid", "startingBalance", "endingBalance"], dtype="float")
+    df.reset_index(inplace=True)
+    df.index += 1
+    df.index.name = "period"
+
+    print(df)

--- a/aiof/retirement/core.py
+++ b/aiof/retirement/core.py
@@ -1,19 +1,23 @@
 import datetime
+from numpy.lib.financial import pmt
 import pandas as pd
 import numpy_financial as npf
 
 import aiof.config as config
 
+from aiof.helpers import fv
+
 
 # Configs
 _settings = config.get_settings()
+_default_interest = _settings.DefaultInterest
 _round_dig = _settings.DefaultRoundingDigit
 
 
 def withdrawal_calc(
     retirement_number: float = None,
     take_out_percentage: float = None,
-    number_of_years: float = None,
+    number_of_years: int = None,
     as_json: bool = False) -> pd.DataFrame:
     """
     Calculate retirement
@@ -24,7 +28,7 @@ def withdrawal_calc(
         retirement number. defaults to `1,000,000`\n
     `take_out_percentage` : float.
         take out percentage of total retirement number. defaults to `3%`\n
-    `number_of_years` : float.
+    `number_of_years` : int.
         number of years to take money out. defaults to `35`
     """
     # Check for None
@@ -43,9 +47,26 @@ def withdrawal_calc(
         raise ValueError("Number of years must be between 0 and 100")
 
     # Initial data frame
-    df = pd.DataFrame(columns=["year", "principalPaid", "interestPaid", "startingBalance", "endingBalance"], dtype="float")
-    df.reset_index(inplace=True)
-    df.index += 1
-    df.index.name = "period"
+    df = pd.DataFrame(columns=["year", "takeOutPercentage", "startingRetirementNumber", "withdrawal", "endingRetirementNumber"], dtype="float")
 
-    print(df)
+    withdrawal = retirement_number * take_out_percentage
+
+    df.loc[0, "year"] = 1
+    df.loc[0, "takeOutPercentage"] = take_out_percentage
+    df.loc[0, "startingRetirementNumber"] = retirement_number
+    df.loc[0, "withdrawal"] = withdrawal
+    df.loc[0, "endingRetirementNumber"] = retirement_number - df.loc[0, "withdrawal"]
+    for year in range(1, int(number_of_years)):
+        df.loc[year, "year"] = year + 1
+        df.loc[year, "takeOutPercentage"] = take_out_percentage
+        df.loc[year, "startingRetirementNumber"] = -npf.fv(
+            rate=_default_interest / 100,
+            nper=1,
+            pmt=0,
+            pv=df.loc[year - 1, "endingRetirementNumber"],
+            when='end')
+        df.loc[year, "withdrawal"] = withdrawal
+        df.loc[year, "endingRetirementNumber"] = df.loc[year, "startingRetirementNumber"] - df.loc[0, "withdrawal"]    
+    df = df.round(_round_dig)
+
+    return df if not as_json else df.to_dict(orient="records")

--- a/aiof/retirement/core.py
+++ b/aiof/retirement/core.py
@@ -41,10 +41,10 @@ def withdrawal_calc(
 
     if retirement_number <= 0:
         raise ValueError("Retirement number cannot be negative")
-    elif take_out_percentage <= 0 or take_out_percentage > 100:
-        raise ValueError("Take out percentage must be between 0 and 100")
+    elif take_out_percentage <= 0 or take_out_percentage > 0.1:
+        raise ValueError("Take out percentage must be between 1 and 100")
     elif number_of_years <= 0 or number_of_years > 100:
-        raise ValueError("Number of years must be between 0 and 100")
+        raise ValueError("Number of years must be between 1 and 100")
 
     # Initial data frame
     df = pd.DataFrame(columns=["year", "takeOutPercentage", "startingRetirementNumber", "withdrawal", "endingRetirementNumber"], dtype="float")
@@ -61,6 +61,9 @@ def withdrawal_calc(
             pmt=0,
             pv=retirement_number - withdrawal,
             when='end')
+
+    if take_out_percentage == 100:
+        return df if not as_json else df.to_dict(orient="records")
 
     for year in range(1, int(number_of_years)):
         df.loc[year, "year"] = year + 1

--- a/aiof/retirement/core.py
+++ b/aiof/retirement/core.py
@@ -62,7 +62,7 @@ def withdrawal_calc(
             pv=retirement_number - withdrawal,
             when='end')
 
-    if take_out_percentage == 100:
+    if take_out_percentage == 0.1:
         return df if not as_json else df.to_dict(orient="records")
 
     for year in range(1, int(number_of_years)):

--- a/aiof/retirement/core.py
+++ b/aiof/retirement/core.py
@@ -39,11 +39,11 @@ def withdrawal_calc(
     # Check and fix parameters
     take_out_percentage = take_out_percentage / 100
 
-    if retirement_number < 0:
+    if retirement_number <= 0:
         raise ValueError("Retirement number cannot be negative")
-    elif take_out_percentage < 0 or take_out_percentage > 100:
+    elif take_out_percentage <= 0 or take_out_percentage > 100:
         raise ValueError("Take out percentage must be between 0 and 100")
-    elif number_of_years < 0 or number_of_years > 100:
+    elif number_of_years <= 0 or number_of_years > 100:
         raise ValueError("Number of years must be between 0 and 100")
 
     # Initial data frame

--- a/aiof/retirement/core.py
+++ b/aiof/retirement/core.py
@@ -55,18 +55,25 @@ def withdrawal_calc(
     df.loc[0, "takeOutPercentage"] = take_out_percentage
     df.loc[0, "startingRetirementNumber"] = retirement_number
     df.loc[0, "withdrawal"] = withdrawal
-    df.loc[0, "endingRetirementNumber"] = retirement_number - df.loc[0, "withdrawal"]
-    for year in range(1, int(number_of_years)):
-        df.loc[year, "year"] = year + 1
-        df.loc[year, "takeOutPercentage"] = take_out_percentage
-        df.loc[year, "startingRetirementNumber"] = -npf.fv(
+    df.loc[0, "endingRetirementNumber"] =-npf.fv(
             rate=_default_interest / 100,
             nper=1,
             pmt=0,
-            pv=df.loc[year - 1, "endingRetirementNumber"],
+            pv=retirement_number - withdrawal,
             when='end')
+
+    for year in range(1, int(number_of_years)):
+        df.loc[year, "year"] = year + 1
+        df.loc[year, "takeOutPercentage"] = take_out_percentage
+        df.loc[year, "startingRetirementNumber"] = df.loc[year - 1, "endingRetirementNumber"]
         df.loc[year, "withdrawal"] = withdrawal
-        df.loc[year, "endingRetirementNumber"] = df.loc[year, "startingRetirementNumber"] - df.loc[0, "withdrawal"]    
+        df.loc[year, "endingRetirementNumber"] = -npf.fv(
+            rate=_default_interest / 100,
+            nper=1,
+            pmt=0,
+            pv=df.loc[year, "startingRetirementNumber"] - df.loc[year, "withdrawal"],
+            when='end')
+    df["year"] = df["year"].astype(int)
     df = df.round(_round_dig)
 
     return df if not as_json else df.to_dict(orient="records")

--- a/api/main.py
+++ b/api/main.py
@@ -3,7 +3,7 @@ import aiof.config as config
 import aiof.helpers as helpers
 
 from aiof.data.asset import ComparableAsset
-from api.routers import fi, car, analytics, market, property
+from api.routers import fi, car, analytics, market, property, retirement
 
 from fastapi import FastAPI, Request, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
@@ -116,3 +116,8 @@ app.include_router(
     property.router,
     prefix="/api/property",
     tags=["property"])
+
+app.include_router(
+    retirement.router,
+    prefix="/api/retirement",
+    tags=["retirement"])

--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,4 @@
 import time
-from warnings import catch_warnings
 import aiof.config as config
 import aiof.helpers as helpers
 
@@ -26,7 +25,7 @@ app.add_middleware(
 
 @app.exception_handler(ValueError)
 async def unicorn_exception_handler(req: Request, ve: ValueError):
-    return write_exception_response(400, ve)
+    return write_exception_response(status_code=400, message=ve)
 
 def write_exception_response(status_code: int, message: str):
     return JSONResponse(

--- a/api/routers/analytics.py
+++ b/api/routers/analytics.py
@@ -1,6 +1,7 @@
 import aiof.analytics.core as a
 
 from aiof.data.analytics import AssetsLiabilitiesRequest
+from aiof.data.life_event import LifeEventRequest
 
 from fastapi import APIRouter
 
@@ -13,3 +14,7 @@ async def analyze(req: AssetsLiabilitiesRequest):
     return a.analyze(
         assets      = req.assets,
         liabilities = req.liabilities)
+
+@router.post("/life/event")
+async def analyze(req: LifeEventRequest):
+    return a.life_event(life_event_request = req)

--- a/api/routers/property.py
+++ b/api/routers/property.py
@@ -1,8 +1,8 @@
 import aiof.property.core as property
 
-from fastapi import APIRouter
-
 from aiof.data.property import MortgageCalculatorRequest
+
+from fastapi import APIRouter
 
 
 router = APIRouter()

--- a/api/routers/retirement.py
+++ b/api/routers/retirement.py
@@ -1,0 +1,17 @@
+import aiof.retirement.core as retirement
+
+from aiof.data.retirement import WithdrawalRequest
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.post("/withdrawal")
+async def withdrawal_calc(req: WithdrawalRequest):
+    return retirement.withdrawal_calc(
+        retirement_number   = req.retirementNumber,
+        take_out_percentage = req.takeOutPercentage,
+        number_of_years     = req.numberOfYears,
+        as_json             = True)

--- a/tests/test_fi_re.py
+++ b/tests/test_fi_re.py
@@ -53,3 +53,4 @@ class FireTestCase(unittest.TestCase):
             assert c.presentValueFour is not None
             assert c.presentValueThree is not None
             assert c.withdrawTwo is not None
+            

--- a/tests/test_life_event.py
+++ b/tests/test_life_event.py
@@ -1,15 +1,47 @@
 import unittest
 
-from aiof.data.life_event import LifeEvent
+from aiof.data.asset import Asset
+from aiof.data.liability import Liability
+from aiof.data.life_event import LifeEventRequest
 
 
 class LifeEventTestCase(unittest.TestCase):
     """
     Life event unit tests
     """
+    _assets = [
+        Asset(name="asset 1",
+            typeName="cash",
+            value=35000),
+        Asset(name="asset 2",
+            typeName="cash",
+            value=8000),
+        Asset(name="asset 3",
+            typeName="stock",
+            value=24999)
+    ]
+    _liabilities = [
+        Liability(name="l1",
+            typeName="personal loan",
+            value=1685.50,
+            years=5,
+            monthlyPayment=35),
+        Liability(name="l2",
+            typeName="student loan",
+            value=25000,
+            years=10,
+            monthlyPayment=208),
+        Liability(name="l3",
+            typeName="car loan",
+            value=34000,
+            years=6,
+            monthlyPayment=500)
+    ]
 
     def test_life_event_definition_issuccessful(self):
-        le = LifeEvent(
+        le = LifeEventRequest(
+            assets = self._assets,
+            liabilities = self._liabilities,
             type = "buying a house",
             amount = 15000.00,
             plannedDate = None)
@@ -20,14 +52,18 @@ class LifeEventTestCase(unittest.TestCase):
     
     def test_life_event_definition_type_isinvalid(self):
         with self.assertRaises(ValueError): 
-            LifeEvent(
+            LifeEventRequest(
+                assets = self._assets,
+                liabilities = self._liabilities,
                 type = "definitelydoesntexist",
                 amount = 15000.00,
                 plannedDate = None)
 
     def test_life_event_definition_type_isnone(self):
         with self.assertRaises(ValueError): 
-            LifeEvent(
+            LifeEventRequest(
+                assets = self._assets,
+                liabilities = self._liabilities,
                 type = None,
                 amount = 15000.00,
                 plannedDate = None)

--- a/tests/test_life_event.py
+++ b/tests/test_life_event.py
@@ -1,0 +1,33 @@
+import unittest
+
+from aiof.data.life_event import LifeEvent
+
+
+class LifeEventTestCase(unittest.TestCase):
+    """
+    Life event unit tests
+    """
+
+    def test_life_event_definition_issuccessful(self):
+        le = LifeEvent(
+            type = "buying a house",
+            amount = 15000.00,
+            plannedDate = None)
+
+        assert le is not None
+        assert le.type is not None
+        assert le.amount > 0
+    
+    def test_life_event_definition_type_isinvalid(self):
+        with self.assertRaises(ValueError): 
+            LifeEvent(
+                type = "definitelydoesntexist",
+                amount = 15000.00,
+                plannedDate = None)
+
+    def test_life_event_definition_type_isnone(self):
+        with self.assertRaises(ValueError): 
+            LifeEvent(
+                type = None,
+                amount = 15000.00,
+                plannedDate = None)

--- a/tests/test_retirement.py
+++ b/tests/test_retirement.py
@@ -1,0 +1,20 @@
+import unittest
+import json
+import math
+
+from aiof.retirement.core import *
+
+
+class RetirementTestCase(unittest.TestCase):
+    """
+    Retirement unit tests
+    """
+
+    def test_withdrawal_calc_defaults(self):
+        self.assert_withdrawal_calc(withdrawal_calc(
+            retirement_number   = None,
+            take_out_percentage = None,
+            number_of_years     = None))
+
+    def assert_withdrawal_calc(self, df):
+        assert df is not None

--- a/tests/test_retirement.py
+++ b/tests/test_retirement.py
@@ -49,6 +49,13 @@ class RetirementTestCase(unittest.TestCase):
                 take_out_percentage = 0,
                 number_of_years     = 30)
 
+    def test_withdrawal_calc_take_out_percentage_bigger_than_100(self):
+        with self.assertRaises(ValueError): 
+            withdrawal_calc(
+                retirement_number   = 1000000,
+                take_out_percentage = 101,
+                number_of_years     = 30)
+
     def test_withdrawal_calc_take_out_percentage_negative(self):
         with self.assertRaises(ValueError): 
             withdrawal_calc(
@@ -62,6 +69,13 @@ class RetirementTestCase(unittest.TestCase):
                 retirement_number   = 1000000,
                 take_out_percentage = 3.5,
                 number_of_years     = 0)
+
+    def test_withdrawal_calc_number_of_years_bigger_than_100(self):
+        with self.assertRaises(ValueError): 
+            withdrawal_calc(
+                retirement_number   = 1000000,
+                take_out_percentage = 3.5,
+                number_of_years     = 101)
 
     def test_withdrawal_calc_number_of_years_negative(self):
         with self.assertRaises(ValueError): 

--- a/tests/test_retirement.py
+++ b/tests/test_retirement.py
@@ -16,6 +16,60 @@ class RetirementTestCase(unittest.TestCase):
             take_out_percentage = None,
             number_of_years     = None))
 
+    def test_withdrawal_calc_valid(self):
+        self.assert_withdrawal_calc(withdrawal_calc(
+            retirement_number   = 1500000,
+            take_out_percentage = 7,
+            number_of_years     = 35))
+
+    def test_withdrawal_calc_valid_2(self):
+        self.assert_withdrawal_calc(withdrawal_calc(
+            retirement_number   = 3000000,
+            take_out_percentage = 3.5,
+            number_of_years     = 40))
+
+    def test_withdrawal_calc_retirement_number_0(self):
+        with self.assertRaises(ValueError): 
+            withdrawal_calc(
+                retirement_number   = 0,
+                take_out_percentage = 3.5,
+                number_of_years     = 30)
+
+    def test_withdrawal_calc_retirement_number_negative(self):
+        with self.assertRaises(ValueError): 
+            withdrawal_calc(
+                retirement_number   = -1000000,
+                take_out_percentage = 3.5,
+                number_of_years     = 30)
+
+    def test_withdrawal_calc_take_out_percentage_0(self):
+        with self.assertRaises(ValueError): 
+            withdrawal_calc(
+                retirement_number   = 1000000,
+                take_out_percentage = 0,
+                number_of_years     = 30)
+
+    def test_withdrawal_calc_take_out_percentage_negative(self):
+        with self.assertRaises(ValueError): 
+            withdrawal_calc(
+                retirement_number   = 1000000,
+                take_out_percentage = -3.5,
+                number_of_years     = 30)
+
+    def test_withdrawal_calc_number_of_years_0(self):
+        with self.assertRaises(ValueError): 
+            withdrawal_calc(
+                retirement_number   = 1000000,
+                take_out_percentage = 3.5,
+                number_of_years     = 0)
+
+    def test_withdrawal_calc_number_of_years_negative(self):
+        with self.assertRaises(ValueError): 
+            withdrawal_calc(
+                retirement_number   = 1000000,
+                take_out_percentage = 3.5,
+                number_of_years     = -30)
+
     def assert_withdrawal_calc(self, df):
         assert df is not None
         assert df.size > 0

--- a/tests/test_retirement.py
+++ b/tests/test_retirement.py
@@ -63,6 +63,13 @@ class RetirementTestCase(unittest.TestCase):
                 take_out_percentage = -3.5,
                 number_of_years     = 30)
 
+    def test_withdrawal_calc_take_out_percentage_100(self):
+        with self.assertRaises(ValueError): 
+            withdrawal_calc(
+                retirement_number   = 1000000,
+                take_out_percentage = 100,
+                number_of_years     = 30)
+
     def test_withdrawal_calc_number_of_years_0(self):
         with self.assertRaises(ValueError): 
             withdrawal_calc(

--- a/tests/test_retirement.py
+++ b/tests/test_retirement.py
@@ -18,3 +18,11 @@ class RetirementTestCase(unittest.TestCase):
 
     def assert_withdrawal_calc(self, df):
         assert df is not None
+        assert df.size > 0
+
+        for i in range (0, len(df)):
+            assert df.loc[i, "year"] >= 1
+            assert df.loc[i, "takeOutPercentage"] > 0
+            assert df.loc[i, "startingRetirementNumber"] > 0
+            assert df.loc[i, "withdrawal"] > 0
+            assert df.loc[i, "endingRetirementNumber"] > 0


### PR DESCRIPTION
Work item: https://github.com/orgs/kamacharovs/projects/1#card-51795275

Added withdrawal retirement calculator. It takes in a `retirementNumber`, `takeOutPercentage` and `numberOfYears`. Then calculates the money left each year as a pandas dataframe and returned as JSON in the API

- added logic for withdrawal calculator
- added unit tests for it
- added (also) some life event logic