### PR TITLE
update fast api to latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # To ensure app dependencies are ported from your virtual environment/host machine into your container, run 'pip freeze > requirements.txt' in the terminal to overwrite this file
-fastapi==0.61.1
+fastapi==0.65.2
 uvicorn==0.11.8
 pytest==6.0.2
 numpy==1.19.0


### PR DESCRIPTION
Hot fix to update fast api because of GitHub `dependabot[bot]` alert

```
[kamacharovs/aiof-metadata] Bump fastapi from 0.61.1 to 0.65.2 (#14)
```