### PR TITLE
hotfix/2021.06/optional-asset-snapshot-fields

### DIFF
--- a/aiof/data/asset.py
+++ b/aiof/data/asset.py
@@ -19,8 +19,8 @@ _default_contribution = 500
 
 class AssetSnapshot(BaseModel):
     assetId: int
-    name: str
-    typeName: str
+    name: Optional[str]
+    typeName: Optional[str]
     value: Optional[float]
     valueChange: Optional[float]
     created: datetime


### PR DESCRIPTION
Hotfix to update optional `name` and `typeName` fields to `AssetSnapshot`